### PR TITLE
Update the blacklist for unrequire

### DIFF
--- a/unrequire.lua
+++ b/unrequire.lua
@@ -9,6 +9,12 @@ local blacklist = {
 	["shell"] = true,
 	["package"] = true,
 	["process"] = true,
+	["unicode"] = true,
+	["computer"] = true,
+	["component"] = true,
+	["_G"] = true,
+	["term"] = true,
+	["keyboard"] = true
 }
 
 local function errprint(msg)


### PR DESCRIPTION
When testing the unrequire tool on OpenOS 1.6.1, I found that it could unload things that broke OpenOS, so I used a process of elimination to find out what not to unload. It seems to work.

Since this involves (removing) the guts of OpenOS (while it's running), maybe @payonel (hopefully this isn't rude) could give his opinion on what is likely to cause issues?

What was odd was that if you unload both `term` and `keyboard`, key combinations stopped working, but if you only unloaded one of them it still worked (until you unloaded the other).