### PR TITLE
Added support for table usage of component.list

### DIFF
--- a/vcomponent/vcomponent.lua
+++ b/vcomponent/vcomponent.lua
@@ -23,13 +23,13 @@ function component.list(filter, exact)
 	for k,v in olist(filter, exact) do
 		data[#data + 1] = k
 		data[#data + 1] = v
-		result[k]=v
+		result[k] = v
 	end
 	for k,v in pairs(typelist) do
 		if filter == nil or (exact and v == filter) or (not exact and v:find(filter, nil, true)) then
 			data[#data + 1] = k
 			data[#data + 1] = v
-			result[k]=v
+			result[k] = v
 		end
 	end
 	local place = 1
@@ -37,7 +37,7 @@ function component.list(filter, exact)
 		{__call=function()
 			local addr,type = data[place], data[place + 1]
 			place = place + 2
-			return addr,type
+			return addr, type
 		end}
 	)
 end

--- a/vcomponent/vcomponent.lua
+++ b/vcomponent/vcomponent.lua
@@ -18,23 +18,28 @@ end
 local olist = component.list
 function component.list(filter, exact)
 	checkArg(1,filter,"string","nil")
+	local result = {}
 	local data = {}
 	for k,v in olist(filter, exact) do
 		data[#data + 1] = k
 		data[#data + 1] = v
+		result[k]=v
 	end
 	for k,v in pairs(typelist) do
 		if filter == nil or (exact and v == filter) or (not exact and v:find(filter, nil, true)) then
 			data[#data + 1] = k
 			data[#data + 1] = v
+			result[k]=v
 		end
 	end
 	local place = 1
-	return function()
-		local addr,type = data[place], data[place + 1]
-		place = place + 2
-		return addr,type
-	end
+	return setmetatable(result, 
+		{__call=function()
+			local addr,type = data[place], data[place + 1]
+			place = place + 2
+			return addr,type
+		end}
+	)
 end
 
 local otype = component.type


### PR DESCRIPTION
Original component.list are return table which look as table and allow iterating
![image](https://user-images.githubusercontent.com/35610168/64645967-b60e2b00-d41e-11e9-8bbc-f8becbc39364.png)
But overwrited version from vcomponent provide only iterate feature. This may cause of incompatibilities. 
Example:
/lib/filesystem.lua # proxy : 206
```lua
function filesystem.proxy(filter, options)
  if not component.list("filesystem")[filter] or next(options or {}) then
    return filesystem.internal.proxy(filter, options)
  end
  return component.proxy(filter)
end
```
This PR provide solve this problem
